### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ _Brief description of the main points of the implementation._
 
 - [ ] Request is assigned to a project maintainer.
 - [ ] Labels are specified according to the type of request:
-  `feature` for features and action items, `fix` for bugs.
+  `feature`/`improvement` for features and action items, `fix` for bugs.
 - [ ] Project is set to `lexibot`.
 - [ ] New unit tests are added for changes that could be tested.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+#### Why the changes are needed
+
+_Brief description of the issue that is being solved by the pull request **or issue number**._
+
+#### How the changes are implemented (if they are complex enough)
+
+_Brief description of the main points of the implementation._
+
+#### All items on this checklist must be completed before merge:
+
+- [ ] Request is assigned to a project maintainer.
+- [ ] Labels are specified according to the type of request:
+  `feature` for features and action items, `fix` for bugs.
+- [ ] Project is set to `lexibot`.
+- [ ] New unit tests are added for changes that could be tested.
+
+Depending on the changes:
+
+- [ ] If there are new dependencies, `make write-deps` was run.
+- [ ] If the user interface of the app was changed, the changes are reflected in the documentation.
+- [ ] If the user interface of the app was changed, the changes are fully localized.


### PR DESCRIPTION
#### Why the changes are needed

Default pull request template is useful so no one would forget about necessary steps, that must be performed before merge.

#### All items on this checklist must be completed before merge:

- [x] Request is assigned to a project maintainer.
- [x] Labels are specified according to the type of request:
  `feature`/`improvement` for features and action items, `fix` for bugs.
- [x] Project is set to `lexibot`.
- [x] New unit tests are added for changes that could be tested.

Depending on the changes:

- [x] If there are new dependencies, `make write-deps` was run.
- [x] If the user interface of the app was changed, the changes are reflected in the documentation.
- [x] If the user interface of the app was changed, the changes are fully localized.
